### PR TITLE
Fixes

### DIFF
--- a/include/dns_cache_base.h
+++ b/include/dns_cache_base.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <list>
-#include <shared_mutex>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -15,15 +15,13 @@ private:
   size_t max_size_;
   std::unordered_map<std::string, CacheEntry> cache_;
   std::list<std::string> lru_list_;
-  mutable std::shared_mutex mutex_;
+  mutable std::mutex mutex_;
 
 protected:
   explicit DNSCacheBase(size_t max_size);
 
 public:
-  virtual ~DNSCacheBase() = default;
-
-  virtual void update(const std::string &name, const std::string &ip);
-  virtual std::string resolve(const std::string &name);
-  virtual size_t getMaxSize() const;
+  void update(const std::string &name, const std::string &ip);
+  std::string resolve(const std::string &name);
+  size_t getMaxSize() const;
 };

--- a/include/dns_cache_base.h
+++ b/include/dns_cache_base.h
@@ -4,17 +4,18 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <functional> 
 
 class DNSCacheBase {
 private:
   struct CacheEntry {
     std::string ip;
-    std::list<std::string>::iterator lru_iterator;
+    std::list<std::reference_wrapper<const std::string>>::iterator lru_iterator;
   };
 
   size_t max_size_;
   std::unordered_map<std::string, CacheEntry> cache_;
-  std::list<std::string> lru_list_;
+  std::list<std::reference_wrapper<const std::string>> lru_list_;
   mutable std::mutex mutex_;
 
 protected:

--- a/src/dns_cache_base.cpp
+++ b/src/dns_cache_base.cpp
@@ -20,8 +20,11 @@ void DNSCacheBase::update(const std::string &name, const std::string &ip) {
       cache_.erase(lru_name);
       lru_list_.pop_back();
     }
-    lru_list_.push_front(name);
-    cache_[name] = {ip, lru_list_.begin()};
+    auto [cache_it, inserted] = cache_.emplace(name, CacheEntry{ip, {}});
+
+    lru_list_.push_front(std::cref(cache_it->first));
+
+    cache_it->second.lru_iterator = lru_list_.begin();
   }
 }
 


### PR DESCRIPTION
+ Delete ```virtual``` in base class
+ Use ```.splice``` method for ```std::list``` to reduce memory allocation/deallocation operations
+ Use ```std::reference_wrapper``` for domain name in list to avoid excessive memory consumption
+ Use ```std::mutex``` instead of ```std::shared_mutex``` because of using only unique locks